### PR TITLE
chore: bump LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 megatank58
+Copyright (c) 2022 megatank58
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Imagine creating a repository for 2022 and having a 2021 license year. Smh.